### PR TITLE
pyproject.toml (Ruff): set the quote-style as "single"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ fix = true
 
 [tool.ruff.format]
 skip-magic-trailing-comma = true
+quote-style = "single"
 
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false


### PR DESCRIPTION
Follow up ([lnls-fac/apsuite#329](https://github.com/lnls-fac/apsuite/pull/329)).

> _By default, the Ruff formatter uses double quotes for string literals. Since we've adopted single quotes as our convention, this configuration ensures Ruff formats accordingly._